### PR TITLE
fix: fix `<i18n>` blocks without lang attribute

### DIFF
--- a/lib/plugins/vite-plugin.js
+++ b/lib/plugins/vite-plugin.js
@@ -11,7 +11,7 @@ export default function i18nPlugin(opts = {}) {
 	return {
 		name: '@whisthub/vue-i18n-precompile',
 		transform(source, id) {
-			if (!filter(id)) return false;
+			if (!filter(id) && !id.includes('vue&type=i18n')) return false;
 
 			// If a parent module transforms json to
 			// `export default {};` it won't properly parse, so try to detect 


### PR DESCRIPTION
Custom `<i18n>` blocks in SFC's did not properly work if no `lang` attribute was set that matches the include filter. Fixed now.