### PR TITLE
feat: create isolated translation contexts

### DIFF
--- a/lib/use-i18n.js
+++ b/lib/use-i18n.js
@@ -17,7 +17,7 @@ export function useI18n(opts = {}) {
 	// for the same problem with Pinia for more info for example.
 	const {
 		i18n = inject($i18n),
-		scope = 'locale',
+		scope = 'local',
 		messages,
 	} = opts;
 
@@ -36,12 +36,16 @@ export function useI18n(opts = {}) {
 
 	// By default we're creating a *local* context. Note that we can only have 
 	// one context per instance, so check if one has already been registered, 
-	// and if so just return it.
+	// and if so just return it. Note however that for composables, it's often 
+	// desiger to *not* tie the context to the component and hence have a 
+	// separate instance. This can be set with `{ scope: 'isolated' }`.
 	const {
 		locale,
 		instance = getCurrentInstance(),
 	} = opts;
-	if (instance && instance[$local]) return instance[$local];
+	if (scope !== 'isolated' && instance && instance[$local]) {
+		return instance[$local];
+	}
 
 	// Cool, no cached context found, that means that we create a fresh new one.
 	const context = createContext(i18n, {
@@ -51,7 +55,7 @@ export function useI18n(opts = {}) {
 
 	// Context has been created, now assign it to this component instance o that 
 	// the <i18n-t> component can find it in the parent chain.
-	if (instance) {
+	if (instance && scope !== 'isolated') {
 		instance[$local] = context;
 	}
 	return context;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@whisthub/vue-i18n",
-  "version": "0.0.1-alpha",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@whisthub/vue-i18n",
-      "version": "0.0.1-alpha",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@intlify/message-compiler": "^9.13.1"
@@ -3283,9 +3283,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/test/use-i18n-test.js
+++ b/test/use-i18n-test.js
@@ -14,7 +14,20 @@ describe('The useI18n function', function() {
 
 	});
 
-	it('provides the root i81n instance', function() {
+	it('allows creating isolated contexts, not tied to the component', function() {
+
+		const i18n = createI18n();
+		const instance = {};
+		const local = useI18n({ i18n, instance });
+		const one = useI18n({ scope: 'isolated', i18n, instance });
+		const two = useI18n({ scope: 'isolated', i18n, instance });
+		expect(one).to.not.equal(two);
+		expect(local).to.not.equal(one);
+		expect(local).to.not.equal(two);
+
+	});
+
+	it('provides the root i18n instance', function() {
 
 		const root = createI18n();
 		const { i18n } = useI18n({ i18n: root });


### PR DESCRIPTION
This PR adds the possibility to get isolated scopes with `useI18n({ scope: 'isolated' })`. This is useful if you want to use `@whisthub/vue-i18n` in your composables, where you want a separate translation context that is not tied to the component, for example if your composable has separate messages that are different from the component messages.