### PR TITLE
fix: don't throw if locale is undefined

### DIFF
--- a/lib/create-context.js
+++ b/lib/create-context.js
@@ -17,7 +17,7 @@ export default function createContext(i18n, opts = {}) {
 	const localeRef = toRef(opts.locale);
 	const { messages = {} } = opts;
 	function lookup(key) {
-		const locale = localeRef.value || toValue(i18n.locale);
+		const locale = localeRef.value || toValue(i18n.locale) || '';
 		return searchMessage(i18n, messages, locale, key);
 	}
 

--- a/test/create-context-test.js
+++ b/test/create-context-test.js
@@ -205,6 +205,14 @@ describe('The context factory', function() {
 
 		});
 
+		it('falls back to the keys if no locale has been set', function() {
+
+			const i18n = this.setup();
+			const { t } = this.ctx(i18n);
+			expect(t('no_locale')).to.equal('no_locale');
+
+		});
+
 	});
 
 });


### PR DESCRIPTION
If you did not specify a locale to `createI18n()`, an error will be thrown where it is not really clear what is happening because we try to read `length` from undefined. Fixed it now by defaulting it to a string. If you've configured warnings, it will show a warning that it could not find the message for the empty locale.