### PR TITLE
fix: specify files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "dependencies": {
     "@intlify/message-compiler": "^11.1.12"
-  }
+  },
+  "files": [
+    "lib/*"
+  ]
 }


### PR DESCRIPTION
Currently the npm package contained all of our tests and the `.github/workflows` folder as well. That's not needed, so we excluded it.